### PR TITLE
Fix Pokedex image syntax

### DIFF
--- a/pokedex/script.js
+++ b/pokedex/script.js
@@ -47,7 +47,7 @@ const createPokemonCard = (pokemon) => {
 
     const pokemonInnerHTML = `
     <div class="img-container">
-        <img src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png"" alt="${name}">
+        <img src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png" alt="${name}">
     </div>
     <div class="info">
         <span class="number">#${id}</span>


### PR DESCRIPTION
## Summary
- fix malformed img tag in Pokedex app

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857db87063c832b903dec9ece037d3c